### PR TITLE
Add health probe endpoint

### DIFF
--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -29,6 +29,10 @@
       "tags": {
       }
     }
+    "healthProbe": {
+      "port": "8000"
+      "unhealthyLatency": "5 minutes"
+    }
   }
 
   "telemetry": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/LoaderApp.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/LoaderApp.scala
@@ -26,7 +26,7 @@ abstract class LoaderApp[SourceConfig: Decoder, SinkConfig: Decoder](
     super.runtimeConfig.copy(cpuStarvationCheckInterval = 10.seconds)
 
   type SinkProvider   = SinkConfig => Resource[IO, Sink[IO]]
-  type SourceProvider = SourceConfig => SourceAndAck[IO]
+  type SourceProvider = SourceConfig => IO[SourceAndAck[IO]]
 
   def source: SourceProvider
   def badSink: SinkProvider

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Run.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Run.scala
@@ -28,7 +28,7 @@ object Run {
 
   def fromCli[F[_]: Async, SourceConfig: Decoder, SinkConfig: Decoder](
     appInfo: AppInfo,
-    toSource: SourceConfig => SourceAndAck[F],
+    toSource: SourceConfig => F[SourceAndAck[F]],
     toBadSink: SinkConfig => Resource[F, Sink[F]]
   ): Opts[F[ExitCode]] = {
     val configPathOpt = Opts.option[Path]("config", help = "path to config file")
@@ -37,7 +37,7 @@ object Run {
 
   private def fromConfigPaths[F[_]: Async, SourceConfig: Decoder, SinkConfig: Decoder](
     appInfo: AppInfo,
-    toSource: SourceConfig => SourceAndAck[F],
+    toSource: SourceConfig => F[SourceAndAck[F]],
     toBadSink: SinkConfig => Resource[F, Sink[F]],
     pathToConfig: Path
   ): F[ExitCode] = {
@@ -55,7 +55,7 @@ object Run {
 
   private def fromConfig[F[_]: Async, SourceConfig, SinkConfig](
     appInfo: AppInfo,
-    toSource: SourceConfig => SourceAndAck[F],
+    toSource: SourceConfig => F[SourceAndAck[F]],
     toBadSink: SinkConfig => Resource[F, Sink[F]],
     config: Config[SourceConfig, SinkConfig]
   ): F[ExitCode] =

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
@@ -17,7 +17,7 @@ import com.snowplowanalytics.snowplow.sinks.Sink
 import com.snowplowanalytics.snowplow.snowflake.processing.{ChannelProvider, TableManager}
 import com.snowplowanalytics.snowplow.loaders.runtime.AppInfo
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 
 case class MockEnvironment(state: Ref[IO, Vector[MockEnvironment.Action]], environment: Environment[IO])
 
@@ -91,6 +91,8 @@ object MockEnvironment {
             state.update(_ :+ Checkpointed(chunk.toList))
           }
           .drain
+
+      def processingLatency: IO[FiniteDuration] = IO.pure(Duration.Zero)
     }
 
   private def testSink(ref: Ref[IO, Vector[Action]]): Sink[IO] = Sink[IO] { batch =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
     val awsSdk2   = "2.20.135"
 
     // Snowplow
-    val streams = "0.1.0-M4"
+    val streams = "0.1.0-M5"
 
     // tests
     val specs2           = "4.20.0"
@@ -50,7 +50,6 @@ object Dependencies {
   val jaxb            = "javax.xml.bind"         % "jaxb-api"             % V.jaxb
   val stsSdk2         = "software.amazon.awssdk" % "sts"                  % V.awsSdk2
 
-  // snowplow: Note jackson-databind 2.14.x is incompatible with Spark
   val streamsCore = "com.snowplowanalytics" %% "streams-core"   % V.streams
   val kinesis     = "com.snowplowanalytics" %% "kinesis"        % V.streams
   val kafka       = "com.snowplowanalytics" %% "kafka"          % V.streams


### PR DESCRIPTION
Adds a http server so the deployment infrastructure (e.g. Kubernetes) can tell when the app is unhealthy.

In this first commit, we say the app is unhealthy only if there is an event which has been stuck for a long time, i.e. held in memory but not yet acked.

In follow-up commits, we can extend the `isHealthy` method to consider the health of other services too.