### PR TITLE
Split out channel resource management into a generic Coldswap

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/AppHealth.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/AppHealth.scala
@@ -12,7 +12,7 @@ object AppHealth {
   def isHealthy[F[_]: Monad](
     config: Config.HealthProbe,
     source: SourceAndAck[F],
-    snowflakeHealth: SnowflakeHealth[F]
+    snowflakeHealth: SnowflakeHealth.Stateful[F]
   ): F[HealthProbe.Status] =
     List(
       sourceIsHealthy(config, source),

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Channel.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Channel.scala
@@ -7,10 +7,7 @@
  */
 package com.snowplowanalytics.snowplow.snowflake.processing
 
-import cats.effect.implicits._
-import cats.effect.kernel.{Ref, Resource}
-import cats.effect.std.{Hotswap, Semaphore}
-import cats.effect.{Async, Poll, Sync}
+import cats.effect.{Async, Resource, Sync}
 import cats.implicits._
 import com.snowplowanalytics.snowplow.snowflake.{Alert, Config, Monitoring}
 import net.snowflake.ingest.streaming.internal.SnowsFlakePlowInterop
@@ -23,23 +20,7 @@ import java.time.ZoneOffset
 import java.util.Properties
 import scala.jdk.CollectionConverters._
 
-trait ChannelProvider[F[_]] {
-
-  /**
-   * Closes the open channel and opens a new channel
-   *
-   * This should be called if the channel becomes invalid. And the channel becomes invalid if the
-   * table is altered by another concurrent loader.
-   */
-  def reset: F[Unit]
-
-  /**
-   * Wraps an action which requires the channel to be closed
-   *
-   * This should be called when altering the table to add new columns. The newly opened channel will
-   * be able to use the new columns.
-   */
-  def withClosedChannel[A](fa: F[A]): F[A]
+trait Channel[F[_]] {
 
   /**
    * Writes rows to Snowflake
@@ -49,10 +30,23 @@ trait ChannelProvider[F[_]] {
    * @return
    *   List of the details of any insert failures. Empty list implies complete success.
    */
-  def write(rows: Iterable[Map[String, AnyRef]]): F[ChannelProvider.WriteResult]
+  def write(rows: Iterable[Map[String, AnyRef]]): F[Channel.WriteResult]
+
+  /** Closes the Snowflake channel */
+  def close: F[Unit]
 }
 
-object ChannelProvider {
+object Channel {
+
+  /**
+   * Provider of open Snowflake channels
+   *
+   * The Provider is not responsible for closing any opened channel. Channel lifecycle must be
+   * managed by the surrounding application code.
+   */
+  trait Provider[F[_]] {
+    def open: F[Channel[F]]
+  }
 
   private implicit def logger[F[_]: Sync] = Slf4jLogger.getLogger[F]
 
@@ -92,88 +86,69 @@ object ChannelProvider {
      *   Contains details of any failures to write events to Snowflake. If the write was completely
      *   successful then this list is empty.
      */
-    case class WriteFailures(value: List[ChannelProvider.WriteFailure]) extends WriteResult
+    case class WriteFailures(value: List[Channel.WriteFailure]) extends WriteResult
 
   }
 
-  /** A large number so we don't limit the number of permits for calls to `flush` and `enqueue` */
-  private val allAvailablePermits: Long = Long.MaxValue
-
-  def make[F[_]: Async](
-    config: Config.Snowflake,
-    snowflakeHealth: SnowflakeHealth[F],
-    batchingConfig: Config.Batching,
-    retriesConfig: Config.Retries,
-    monitoring: Monitoring[F]
-  ): Resource[F, ChannelProvider[F]] =
+  def provider[F[_]: Async](config: Config.Snowflake, batchingConfig: Config.Batching): Resource[F, Provider[F]] =
     for {
       client <- createClient(config, batchingConfig)
-      channelResource = createChannel(config, client, snowflakeHealth, retriesConfig, monitoring)
-      (hs, channel) <- Hotswap.apply(channelResource)
-      ref <- Resource.eval(Ref[F].of(channel))
-      sem <- Resource.eval(Semaphore[F](allAvailablePermits))
-    } yield impl(ref, hs, sem, channelResource)
-
-  private def impl[F[_]: Async](
-    ref: Ref[F, SnowflakeStreamingIngestChannel],
-    hs: Hotswap[F, SnowflakeStreamingIngestChannel],
-    sem: Semaphore[F],
-    next: Resource[F, SnowflakeStreamingIngestChannel]
-  ): ChannelProvider[F] =
-    new ChannelProvider[F] {
-      def reset: F[Unit] =
-        withAllPermits(sem) { // Must have **all** permits so we don't conflict with a write
-          ref.get.flatMap { channel =>
-            if (channel.isValid())
-              // We might have concurrent fibers calling `reset`.  This just means another fiber
-              // has already reset this channel.
-              Sync[F].unit
-            else
-              Sync[F].uncancelable { _ =>
-                for {
-                  _ <- hs.clear
-                  channel <- hs.swap(next)
-                  _ <- ref.set(channel)
-                } yield ()
-              }
-          }
-        }
-
-      def withClosedChannel[A](fa: F[A]): F[A] =
-        withAllPermits(sem) { // Must have **all** permites so we don't conflict with a write
-          Sync[F].uncancelable { _ =>
-            for {
-              _ <- hs.clear
-              a <- fa
-              channel <- hs.swap(next)
-              _ <- ref.set(channel)
-            } yield a
-          }
-        }
-
-      def write(rows: Iterable[Map[String, AnyRef]]): F[WriteResult] =
-        sem.permit
-          .use[WriteResult] { _ =>
-            for {
-              channel <- ref.get
-              response <- Sync[F].blocking(channel.insertRows(rows.map(_.asJava).asJava, null))
-              _ <- flushChannel[F](channel)
-              isValid <- Sync[F].delay(channel.isValid)
-            } yield if (isValid) WriteResult.WriteFailures(parseResponse(response)) else WriteResult.ChannelIsInvalid
-          }
-          .recover {
-            case sfe: SFException if sfe.getVendorCode === SFErrorCode.INVALID_CHANNEL.getMessageCode =>
-              WriteResult.ChannelIsInvalid
-          }
+    } yield new Provider[F] {
+      def open: F[Channel[F]] = createChannel[F](config, client).map(impl[F])
     }
 
-  /** Wraps a `F[A]` so it only runs when no other fiber is using the channel at the same time */
-  private def withAllPermits[F[_]: Sync, A](sem: Semaphore[F])(f: F[A]): F[A] =
-    Sync[F].uncancelable { poll =>
-      for {
-        _ <- poll(sem.acquireN(allAvailablePermits))
-        a <- f.guarantee(sem.releaseN(allAvailablePermits))
-      } yield a
+  def providerToColdswap[F[_]: Async](
+    provider: Provider[F],
+    retries: Config.Retries,
+    health: SnowflakeHealth[F],
+    monitoring: Monitoring[F]
+  ): Resource[F, Coldswap[F, Channel[F]]] =
+    Coldswap.make(providerToResource(provider, retries, health, monitoring))
+
+  private def providerToResource[F[_]: Async](
+    provider: Provider[F],
+    retries: Config.Retries,
+    health: SnowflakeHealth[F],
+    monitoring: Monitoring[F]
+  ): Resource[F, Channel[F]] =
+    SnowflakeRetrying.retryIndefinitelyResource(health, retries) {
+      Resource
+        .make(provider.open)(_.close)
+        .onError { cause =>
+          Resource.eval(monitoring.alert(Alert.FailedToOpenSnowflakeChannel(cause)))
+        }
+    }
+
+  private def impl[F[_]: Async](channel: SnowflakeStreamingIngestChannel): Channel[F] =
+    new Channel[F] {
+
+      def write(rows: Iterable[Map[String, AnyRef]]): F[WriteResult] = {
+        val attempt: F[WriteResult] = for {
+          response <- Sync[F].blocking(channel.insertRows(rows.map(_.asJava).asJava, null))
+          _ <- flushChannel[F](channel)
+          isValid <- Sync[F].delay(channel.isValid)
+        } yield if (isValid) WriteResult.WriteFailures(parseResponse(response)) else WriteResult.ChannelIsInvalid
+
+        attempt.recover {
+          case sfe: SFException if sfe.getVendorCode === SFErrorCode.INVALID_CHANNEL.getMessageCode =>
+            WriteResult.ChannelIsInvalid
+        }
+      }
+
+      def close: F[Unit] =
+        Logger[F].info(s"Closing channel ${channel.getFullyQualifiedName()}") *>
+          Async[F]
+            .fromCompletableFuture {
+              Async[F].delay {
+                channel.close()
+              }
+            }
+            .void
+            .recover {
+              case sfe: SFException if sfe.getVendorCode === SFErrorCode.INVALID_CHANNEL.getMessageCode =>
+                // We have already handled errors associated with invalid channel
+                ()
+            }
     }
 
   private def parseResponse(response: InsertValidationResponse): List[WriteFailure] =
@@ -187,11 +162,8 @@ object ChannelProvider {
 
   private def createChannel[F[_]: Async](
     config: Config.Snowflake,
-    client: SnowflakeStreamingIngestClient,
-    snowflakeHealth: SnowflakeHealth[F],
-    retriesConfig: Config.Retries,
-    monitoring: Monitoring[F]
-  ): Resource[F, SnowflakeStreamingIngestChannel] = {
+    client: SnowflakeStreamingIngestClient
+  ): F[SnowflakeStreamingIngestChannel] = {
     val request = OpenChannelRequest
       .builder(config.channel)
       .setDBName(config.database)
@@ -201,32 +173,8 @@ object ChannelProvider {
       .setDefaultTimezone(ZoneOffset.UTC)
       .build
 
-    def make(poll: Poll[F]) = poll {
-      Logger[F].info(s"Opening channel ${config.channel}") *>
-        SnowflakeRetrying.retryIndefinitely(snowflakeHealth, retriesConfig) {
-          Async[F]
-            .blocking(client.openChannel(request))
-            .onError { cause =>
-              monitoring.alert(Alert.FailedToOpenSnowflakeChannel(cause))
-            }
-        }
-    }
-
-    Resource.makeFull(make) { channel =>
-      Logger[F].info(s"Closing channel ${config.channel}") *>
-        Async[F]
-          .fromCompletableFuture {
-            Async[F].delay {
-              channel.close()
-            }
-          }
-          .void
-          .recover {
-            case sfe: SFException if sfe.getVendorCode === SFErrorCode.INVALID_CHANNEL.getMessageCode =>
-              // We have already handled errors associated with invalid channel
-              ()
-          }
-    }
+    Logger[F].info(s"Opening channel ${config.channel}") *>
+      Async[F].blocking(client.openChannel(request))
   }
 
   private def channelProperties(config: Config.Snowflake, batchingConfig: Config.Batching): Properties = {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Coldswap.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Coldswap.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.snowflake.processing
+
+import cats.effect.{Async, Ref, Resource, Sync}
+import cats.effect.std.Semaphore
+import cats.Functor
+import cats.implicits._
+
+/**
+ * Manages swapping of Resources
+ *
+ * Inspired by `cats.effect.std.Hotswap` but with differences. A Hotswap is "hot" because a `swap`
+ * acquires the next resource before closing the previous one. Whereas this Coldswap is "cold"
+ * because it always closes any previous Resources before acquiring the next one.
+ *
+ * * '''Note''': The resource cannot be simultaneously open and closed, and so
+ * `coldswap.opened.surround(coldswap.closed.use_)` will deadlock.
+ */
+final class Coldswap[F[_]: Sync, A] private (
+  sem: Semaphore[F],
+  ref: Ref[F, Coldswap.State[F, A]],
+  resource: Resource[F, A]
+) {
+  import Coldswap._
+
+  /**
+   * Gets the current resource, or opens a new one if required. The returned `A` is guaranteed to be
+   * available for the duration of the `Resource.use` block.
+   */
+  def opened: Resource[F, A] =
+    (sem.permit *> Resource.eval[F, State[F, A]](ref.get)).flatMap {
+      case Opened(a, _) => Resource.pure(a)
+      case Closed =>
+        for {
+          _ <- releaseHeldPermit(sem)
+          _ <- acquireAllPermits(sem)
+          a <- Resource.eval(doOpen(ref, resource))
+        } yield a
+    }
+
+  /**
+   * Closes the resource if it was open. The resource is guaranteed to remain closed for the
+   * duration of the `Resource.use` block.
+   */
+  def closed: Resource[F, Unit] =
+    (sem.permit *> Resource.eval(ref.get)).flatMap {
+      case Closed => Resource.unit
+      case Opened(_, _) =>
+        for {
+          _ <- releaseHeldPermit(sem)
+          _ <- acquireAllPermits(sem)
+          _ <- Resource.eval(doClose(ref))
+        } yield ()
+    }
+
+}
+
+object Coldswap {
+
+  private sealed trait State[+F[_], +A]
+  private case object Closed extends State[Nothing, Nothing]
+  private case class Opened[F[_], A](value: A, close: F[Unit]) extends State[F, A]
+
+  def make[F[_]: Async, A](resource: Resource[F, A]): Resource[F, Coldswap[F, A]] =
+    for {
+      sem <- Resource.eval(Semaphore[F](Long.MaxValue))
+      ref <- Resource.eval(Ref.of[F, State[F, A]](Closed))
+      _ <- Resource.onFinalize(acquireAllPermits(sem).use(_ => doClose(ref)))
+    } yield new Coldswap(sem, ref, resource)
+
+  private def releaseHeldPermit[F[_]: Functor](sem: Semaphore[F]): Resource[F, Unit] =
+    Resource.makeFull[F, Unit](poll => poll(sem.release))(_ => sem.acquire)
+
+  private def acquireAllPermits[F[_]: Functor](sem: Semaphore[F]): Resource[F, Unit] =
+    Resource.makeFull[F, Unit](poll => poll(sem.acquireN(Long.MaxValue)))(_ => sem.releaseN(Long.MaxValue))
+
+  private def doClose[F[_]: Sync, A](ref: Ref[F, State[F, A]]): F[Unit] =
+    ref.get.flatMap {
+      case Closed => Sync[F].unit
+      case Opened(_, close) =>
+        Sync[F].uncancelable { _ =>
+          close *> ref.set(Closed)
+        }
+    }
+
+  private def doOpen[F[_]: Sync, A](ref: Ref[F, State[F, A]], resource: Resource[F, A]): F[A] =
+    ref.get.flatMap {
+      case Opened(a, _) => Sync[F].pure(a)
+      case Closed =>
+        Sync[F].uncancelable { _ =>
+          for {
+            (a, close) <- resource.allocated
+            _ <- ref.set(Opened(a, close))
+          } yield a
+        }
+    }
+
+}

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeHealth.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeHealth.scala
@@ -3,18 +3,22 @@ package com.snowplowanalytics.snowplow.snowflake.processing
 import cats.effect.{Concurrent, Ref}
 import cats.implicits._
 import com.snowplowanalytics.snowplow.runtime.HealthProbe
-import com.snowplowanalytics.snowplow.snowflake.processing.SnowflakeHealth.unhealthy
 
-final case class SnowflakeHealth[F[_]](state: Ref[F, HealthProbe.Status]) {
-  def setUnhealthy(): F[Unit] = state.set(unhealthy)
-  def setHealthy(): F[Unit]   = state.set(HealthProbe.Healthy)
+trait SnowflakeHealth[F[_]] {
+  def setUnhealthy(): F[Unit]
+  def setHealthy(): F[Unit]
 }
 
 object SnowflakeHealth {
   private val unhealthy = HealthProbe.Unhealthy("Snowflake connection is not healthy")
 
-  def initUnhealthy[F[_]: Concurrent]: F[SnowflakeHealth[F]] =
+  final case class Stateful[F[_]](state: Ref[F, HealthProbe.Status]) extends SnowflakeHealth[F] {
+    def setUnhealthy(): F[Unit] = state.set(unhealthy)
+    def setHealthy(): F[Unit]   = state.set(HealthProbe.Healthy)
+  }
+
+  def initUnhealthy[F[_]: Concurrent]: F[Stateful[F]] =
     Ref
       .of[F, HealthProbe.Status](unhealthy)
-      .map(SnowflakeHealth.apply)
+      .map(Stateful.apply)
 }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/processing/ProcessingSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/processing/ProcessingSpec.scala
@@ -49,6 +49,7 @@ class ProcessingSpec extends Specification with CatsEffect {
       Vector(
         Action.InitEventsTable,
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(4),
         Action.AddedGoodCountMetric(4),
         Action.AddedBadCountMetric(0),
@@ -87,6 +88,7 @@ class ProcessingSpec extends Specification with CatsEffect {
       Vector(
         Action.InitEventsTable,
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(6),
         Action.SentToBad(6),
         Action.AddedGoodCountMetric(6),
@@ -115,10 +117,12 @@ class ProcessingSpec extends Specification with CatsEffect {
       Vector(
         Action.InitEventsTable,
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(1),
         Action.ClosedChannel,
         Action.AlterTableAddedColumns(List("unstruct_event_xyz_1", "contexts_abc_2")),
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(1),
         Action.AddedGoodCountMetric(2),
         Action.AddedBadCountMetric(0),
@@ -147,6 +151,7 @@ class ProcessingSpec extends Specification with CatsEffect {
       Vector(
         Action.InitEventsTable,
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(1),
         Action.SentToBad(1),
         Action.AddedGoodCountMetric(1),
@@ -176,6 +181,7 @@ class ProcessingSpec extends Specification with CatsEffect {
       Vector(
         Action.InitEventsTable,
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(1),
         Action.ClosedChannel
       )
@@ -197,8 +203,10 @@ class ProcessingSpec extends Specification with CatsEffect {
       Vector(
         Action.InitEventsTable,
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.ClosedChannel,
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(2),
         Action.AddedGoodCountMetric(2),
         Action.AddedBadCountMetric(0),
@@ -228,6 +236,7 @@ class ProcessingSpec extends Specification with CatsEffect {
         Action.SetLatencyMetric(42123),
         Action.SetLatencyMetric(42123),
         Action.OpenedChannel,
+        Action.BecomeHealthy,
         Action.WroteRowsToSnowflake(4),
         Action.AddedGoodCountMetric(4),
         Action.AddedBadCountMetric(0),

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -28,6 +28,7 @@ object BuildSettings {
     scalafmtOnCompile := false,
     scalacOptions += "-Ywarn-macros:after",
     addCompilerPlugin(Dependencies.betterMonadicFor),
+    addCompilerPlugin(Dependencies.kindProjector),
     ThisBuild / dynverVTagPrefix := false, // Otherwise git tags required to have v-prefix
     ThisBuild / dynverSeparator := "-", // to be compatible with docker
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
     val circe            = "0.14.3"
     val betterMonadicFor = "0.3.1"
     val doobie           = "1.0.0-RC4"
+    val kindProjector    = "0.13.2"
 
     // java
     val slf4j     = "2.0.7"
@@ -43,6 +44,7 @@ object Dependencies {
   val circeGenericExtra = "io.circe"         %% "circe-generic-extras" % V.circe
   val betterMonadicFor  = "com.olegpy"       %% "better-monadic-for"   % V.betterMonadicFor
   val doobie            = "org.tpolecat"     %% "doobie-core"          % V.doobie
+  val kindProjector     = "org.typelevel"    %% "kind-projector"       % V.kindProjector cross CrossVersion.full
 
   // java
   val slf4j           = "org.slf4j"              % "slf4j-simple"         % V.slf4j


### PR DESCRIPTION
This is an experiment based on the ideas in #15.  It adds a `Coldswap` which has already been described in #15.  But now it also splits out `Channel` and `ChannelProvider` into separate traits.

I haven't made the tests compile yet.