### PR TITLE
Treat all client errors as setup errors when opening channel

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeRetrying.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeRetrying.scala
@@ -59,8 +59,11 @@ object SnowflakeRetrying {
 
   /** Is an error associated with setting up Snowflake as a destination */
   private def isSetupError[F[_]: Sync](t: Throwable): F[Boolean] = t match {
-    case CausedByIngestResponseException(ire) if ire.getErrorCode === 403 =>
-      true.pure[F]
+    case CausedByIngestResponseException(ire) =>
+      if (ire.getErrorCode >= 400 && ire.getErrorCode < 500)
+        true.pure[F]
+      else
+        false.pure[F]
     case _: SecurityException =>
       // Authentication failure, i.e. user unrecognized or bad private key
       true.pure[F]


### PR DESCRIPTION
Snowflake responds with a 4xx response code for various reasons when opening a channel:

- Credentials are invalid (403)
- This table type does not support channels (400)
- Snowflake schema / table / role / whatever does not exist or we don't have privileges (400)
- There are probably others I have not seen yet!

Before this PR, if we treated the 403 as a setup error, but actually all 4xxs are probably setup errors. We should treat them gracefully by staying alive and sending an informative message to the monitoring webhook.