### PR TITLE
Add collector to target latency metrics -- amendment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         uses: sbt/setup-sbt@v1
       - name: Check Scala formatting
         run: sbt scalafmtCheckAll scalafmtSbtCheck
-#      - name: Run tests
-#        run: sbt test
+      - name: Run tests
+        run: sbt test
 
   publish_docker:
     needs: test

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
@@ -21,6 +21,7 @@ import fs2.Stream
 import org.http4s.client.Client
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import java.time.Instant
 
 case class MockEnvironment(state: Ref[IO, Vector[MockEnvironment.Action]], environment: Environment[IO])
 
@@ -178,6 +179,11 @@ object MockEnvironment {
 
     def setLatencyMillis(latencyMillis: Long): IO[Unit] =
       ref.update(_ :+ SetLatencyMetric(latencyMillis))
+
+    def setLatencyCollectorToTargetMillis(latencyMillis: Long): IO[Unit]                   = IO.unit
+    def setLatencyCollectorToTargetPessimisticMillis(latencyMillis: Long): IO[Unit]        = IO.unit
+    def addOutstandingBatch(token: Unique.Token, maxCollectorTimestamp: Instant): IO[Unit] = IO.unit
+    def clearOutstandingBatch(token: Unique.Token): IO[Unit]                               = IO.unit
 
     def report: Stream[IO, Nothing] = Stream.never[IO]
   }


### PR DESCRIPTION
This version holds onto a map of batches that are in memory but not yet loaded. This means we can report latency of in-memory batches under all of the following circumstances:

- Loader is doing long backoff and retry due to snowflake setup issue (e.g. expired password)
- Loader is stuck trying to open a connection to snowflake due to a transient network issue
- Loader is trying to shutdown due to any other runtime exception