### PR TITLE
Snowflake Ingest SDK logs adhere to application's log level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,14 +27,14 @@ lazy val core: Project = project
 
 lazy val kafka: Project = project
   .in(file("modules/kafka"))
-  .settings(BuildSettings.kafkaSettings)
+  .settings(BuildSettings.kafkaSettings ++ BuildSettings.dockerSettingsUbuntu)
   .settings(libraryDependencies ++= Dependencies.kafkaDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
 lazy val kafkaDistroless: Project = project
   .in(file("modules/distroless/kafka"))
-  .settings(BuildSettings.kafkaSettings)
+  .settings(BuildSettings.kafkaSettings ++ BuildSettings.dockerSettingsDistroless)
   .settings(libraryDependencies ++= Dependencies.kafkaDependencies)
   .settings(sourceDirectory := (kafka / sourceDirectory).value)
   .dependsOn(core)
@@ -42,14 +42,14 @@ lazy val kafkaDistroless: Project = project
 
 lazy val pubsub: Project = project
   .in(file("modules/pubsub"))
-  .settings(BuildSettings.pubsubSettings)
+  .settings(BuildSettings.pubsubSettings ++ BuildSettings.dockerSettingsUbuntu)
   .settings(libraryDependencies ++= Dependencies.pubsubDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
 lazy val pubsubDistroless: Project = project
   .in(file("modules/distroless/pubsub"))
-  .settings(BuildSettings.pubsubSettings)
+  .settings(BuildSettings.pubsubSettings ++ BuildSettings.dockerSettingsDistroless)
   .settings(libraryDependencies ++= Dependencies.pubsubDependencies)
   .settings(sourceDirectory := (pubsub / sourceDirectory).value)
   .dependsOn(core)
@@ -57,14 +57,14 @@ lazy val pubsubDistroless: Project = project
 
 lazy val kinesis: Project = project
   .in(file("modules/kinesis"))
-  .settings(BuildSettings.kinesisSettings)
+  .settings(BuildSettings.kinesisSettings ++ BuildSettings.dockerSettingsUbuntu)
   .settings(libraryDependencies ++= Dependencies.kinesisDependencies)
   .dependsOn(core)
   .enablePlugins(BuildInfoPlugin, JavaAppPackaging, SnowplowDockerPlugin)
 
 lazy val kinesisDistroless: Project = project
   .in(file("modules/distroless/kinesis"))
-  .settings(BuildSettings.kinesisSettings)
+  .settings(BuildSettings.kinesisSettings ++ BuildSettings.dockerSettingsDistroless)
   .settings(libraryDependencies ++= Dependencies.kinesisDependencies)
   .settings(sourceDirectory := (kinesis / sourceDirectory).value)
   .dependsOn(core)

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -18,6 +18,7 @@ import sbtbuildinfo.BuildInfoPlugin.autoImport._
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 import sbtdynver.DynVerPlugin.autoImport._
 import com.typesafe.sbt.packager.docker.DockerPlugin.autoImport._
+import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 
 import scala.sys.process._
@@ -60,6 +61,17 @@ object BuildSettings {
       "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE" -> "secretKeyPassphrase",
       "HOSTNAME" -> "testWorkerId"
     )
+  )
+
+  lazy val dockerSettingsUbuntu = Seq(
+    Universal / javaOptions ++= Seq("-Dnet.snowflake.jdbc.loggerImpl=net.snowflake.client.log.SLF4JLogger")
+  )
+
+  lazy val dockerSettingsDistroless = Seq(
+    dockerEntrypoint := {
+      val orig = dockerEntrypoint.value
+      orig.head +: "-Dnet.snowflake.jdbc.loggerImpl=net.snowflake.client.log.SLF4JLogger" +: orig.tail
+    }
   )
 
   lazy val appSettings = Seq(


### PR DESCRIPTION
Since the 0.2.4 release, the application logs contain lots of extra log lines, e.g.:

```
Oct 21, 2024 8:19:50 PM net.snowflake.client.jdbc.cloud.storage.SnowflakeS3Client upload
INFO: Starting upload from stream (byte stream) to S3 location: <redacted>/streaming_ingest/2024/10/21/20/19/<redacted>_1003_24_0.bdec
```

This fix makes the snowflake sdk use SLF4J as the logger. Therefore it only logs at WARN or above by default.