### PR TITLE
Bump common-streams to 0.8.1

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
     val protobuf  = "3.25.5" // Version override
 
     // Snowplow
-    val streams = "0.8.0-M6"
+    val streams = "0.8.1"
 
     // tests
     val specs2           = "4.20.0"


### PR DESCRIPTION
See snowplow-incubator/common-streams#97 for details.

This fixes an edge-case problem in which the loader did not properly load contexts if they were not JSON objects.