### PR TITLE
Make better use of available cpu on larger VMs

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -44,7 +44,7 @@
 
       # -- Prefix to use for the snowflake channels.
       # -- The full name will be suffixed with a number, e.g. `snowplow-1`
-      # -- The prefix be unique per loader VM
+      # -- The prefix must be unique per loader VM
       "channel": "snowplow"
 
       # -- Timeouts used for JDBC operations
@@ -77,7 +77,7 @@
     # - Events are emitted to Snowflake for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - Controls ow many batches can we send simultaneously over the network to Snowflake.
+    # - Controls how many batches can we send simultaneously over the network to Snowflake.
     # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
     # -- Adjusting this value can cause the app to use more or less of the available CPU.
     "uploadParallelismFactor":  2.5

--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -42,7 +42,9 @@
       # -- name to use for the events table.
       "table": "events"
 
-      # -- name to use for the snowflake channel.
+      # -- Prefix to use for the snowflake channels.
+      # -- The full name will be suffixed with a number, e.g. `snowplow-1`
+      # -- The prefix be unique per loader VM
       "channel": "snowplow"
 
       # -- Timeouts used for JDBC operations
@@ -75,9 +77,16 @@
     # - Events are emitted to Snowflake for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - How many batches can we send simultaneously over the network to Snowflake.
-    "uploadConcurrency":  1
+    # - Controls ow many batches can we send simultaneously over the network to Snowflake.
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "uploadParallelismFactor":  2.5
   }
+
+  # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.
+  # -- E.g. If there are 4 available processors, and cpuParallelismFactor = 0.75, then we process 3 batches concurrently.
+  # -- Adjusting this value can cause the app to use more or less of the available CPU.
+  "cpuParallelismFactor": 0.75
 
   # Retry configuration for Snowflake operation failures
   "retries": {

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -58,7 +58,7 @@
 
       # -- Prefix to use for the snowflake channels.
       # -- The full name will be suffixed with a number, e.g. `snowplow-1`
-      # -- The prefix be unique per loader VM
+      # -- The prefix must be unique per loader VM
       "channel": "snowplow"
 
       # -- Timeouts used for JDBC operations
@@ -94,7 +94,7 @@
     # - Events are emitted to Snowflake for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - Controls ow many batches can we send simultaneously over the network to Snowflake.
+    # - Controls how many batches can we send simultaneously over the network to Snowflake.
     # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
     # -- Adjusting this value can cause the app to use more or less of the available CPU.
     "uploadParallelismFactor":  2.5

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -56,7 +56,9 @@
       # -- name to use for the events table.
       "table": "events"
 
-      # -- name to use for the snowflake channel.
+      # -- Prefix to use for the snowflake channels.
+      # -- The full name will be suffixed with a number, e.g. `snowplow-1`
+      # -- The prefix be unique per loader VM
       "channel": "snowplow"
 
       # -- Timeouts used for JDBC operations
@@ -92,9 +94,16 @@
     # - Events are emitted to Snowflake for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - How many batches can we send simultaneously over the network to Snowflake.
-    "uploadConcurrency":  1
+    # - Controls ow many batches can we send simultaneously over the network to Snowflake.
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "uploadParallelismFactor":  2.5
   }
+
+  # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.
+  # -- E.g. If there are 4 available processors, and cpuParallelismFactor = 0.75, then we process 3 batches concurrently.
+  # -- Adjusting this value can cause the app to use more or less of the available CPU.
+  "cpuParallelismFactor": 0.75
 
   # Retry configuration for Snowflake operation failures
   "retries": {

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -52,7 +52,9 @@
       # -- name to use for the events table.
       "table": "events"
 
-      # -- name to use for the snowflake channel.
+      # -- Prefix to use for the snowflake channels.
+      # -- The full name will be suffixed with a number, e.g. `snowplow-1`
+      # -- The prefix be unique per loader VM
       "channel": "snowplow"
 
       # -- Timeouts used for JDBC operations
@@ -81,9 +83,16 @@
     # - Events are emitted to Snowflake for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - How many batches can we send simultaneously over the network to Snowflake.
-    "uploadConcurrency":  1
+    # - Controls ow many batches can we send simultaneously over the network to Snowflake.
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
+    # -- Adjusting this value can cause the app to use more or less of the available CPU.
+    "uploadParallelismFactor":  2.5
   }
+
+  # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.
+  # -- E.g. If there are 4 available processors, and cpuParallelismFactor = 0.75, then we process 3 batches concurrently.
+  # -- Adjusting this value can cause the app to use more or less of the available CPU.
+  "cpuParallelismFactor": 0.75
 
   # Retry configuration for Snowflake operation failures
   "retries": {

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -54,7 +54,7 @@
 
       # -- Prefix to use for the snowflake channels.
       # -- The full name will be suffixed with a number, e.g. `snowplow-1`
-      # -- The prefix be unique per loader VM
+      # -- The prefix must be unique per loader VM
       "channel": "snowplow"
 
       # -- Timeouts used for JDBC operations
@@ -83,7 +83,7 @@
     # - Events are emitted to Snowflake for a maximum of this duration, even if the `maxBytes` size has not been reached
     "maxDelay": "1 second"
 
-    # - Controls ow many batches can we send simultaneously over the network to Snowflake.
+    # - Controls how many batches can we send simultaneously over the network to Snowflake.
     # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
     # -- Adjusting this value can cause the app to use more or less of the available CPU.
     "uploadParallelismFactor":  2.5

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -21,8 +21,9 @@
   "batching": {
     "maxBytes": 16000000
     "maxDelay": "1 second"
-    "uploadConcurrency":  3
+    "uploadParallelismFactor":  2.5
   }
+  "cpuParallelismFactor": 0.75
 
   "retries": {
     "setupErrors": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Config.scala
@@ -29,6 +29,7 @@ case class Config[+Source, +Sink](
   input: Source,
   output: Config.Output[Sink],
   batching: Config.Batching,
+  cpuParallelismFactor: BigDecimal,
   retries: Config.Retries,
   skipSchemas: List[SchemaCriterion],
   telemetry: Telemetry.Config,
@@ -69,7 +70,7 @@ object Config {
   case class Batching(
     maxBytes: Long,
     maxDelay: FiniteDuration,
-    uploadConcurrency: Int
+    uploadParallelismFactor: BigDecimal
   )
 
   case class Metrics(

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Processing.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Processing.scala
@@ -143,7 +143,6 @@ object Processing {
       }
     }
 
-  /** Parse raw bytes into Event using analytics sdk */
   private def parseAndTransform[F[_]: Async](env: Environment[F], badProcessor: BadRowProcessor): Pipe[F, TokenedEvents, TransformedBatch] =
     _.parEvalMap(env.cpuParallelism) { case TokenedEvents(chunk, token, _) =>
       for {

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
@@ -56,16 +56,17 @@ object MockEnvironment {
         badSink      = testBadSink(mocks.badSinkResponse, state),
         httpClient   = testHttpClient,
         tableManager = testTableManager(state),
-        channel      = channelColdswap,
+        channels     = Vector(channelColdswap),
         metrics      = testMetrics(state),
         appHealth    = testAppHealth(state),
         batching = Config.Batching(
-          maxBytes          = 16000000,
-          maxDelay          = 10.seconds,
-          uploadConcurrency = 1
+          maxBytes                = 16000000,
+          maxDelay                = 10.seconds,
+          uploadParallelismFactor = BigDecimal(1)
         ),
-        schemasToSkip = List.empty,
-        badRowMaxSize = 1000000
+        cpuParallelism = 2,
+        schemasToSkip  = List.empty,
+        badRowMaxSize  = 1000000
       )
       MockEnvironment(state, env)
     }

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
@@ -105,10 +105,11 @@ object KafkaConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 3
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = BigDecimal(2.5)
     ),
+    cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
@@ -185,10 +186,11 @@ object KafkaConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 1
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = BigDecimal(2.5)
     ),
+    cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
@@ -101,10 +101,11 @@ object KinesisConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 3
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = BigDecimal(2.5)
     ),
+    cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
@@ -176,10 +177,11 @@ object KinesisConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 1
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = BigDecimal(2.5)
     ),
+    cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
@@ -101,10 +101,11 @@ object PubsubConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 3
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = BigDecimal(2.5)
     ),
+    cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
@@ -175,10 +176,11 @@ object PubsubConfigSpec {
       )
     ),
     batching = Config.Batching(
-      maxBytes          = 16000000,
-      maxDelay          = 1.second,
-      uploadConcurrency = 1
+      maxBytes                = 16000000,
+      maxDelay                = 1.second,
+      uploadParallelismFactor = BigDecimal(2.5)
     ),
+    cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
       setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
       transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)


### PR DESCRIPTION
These changes allow the loader to better utilize all cpu available on a larger instance.

**1. CPU-intensive parsing/transforming is now parallelized**. Parallelism is configured by a new config parameter `cpuParallelismFraction`. The actual parallelism is chosen dynamically based on the number of available CPU, so the default value should be appropriate for all sized VMs.

**2. We now open a new Snowflake ingest client per channel**. Note the Snowflake SDK recommends to re-use a single Client per VM and open multiple Channels on the same Client.  So here we are going against the recommendations.  But, we justify it because it gives the loader better visiblity of when the client's Future completes, signifying a complete write to Snowflake.

**3. Upload parallelism chosen dynamically**. Larger VMs benefit from higher upload parallelism, in order to keep up with the faster rate of batches produced by the cpu-intensive tasks. Parallelsim is configured by a new parameter `uploadParallelismFactor`, which gets multiplied by the number of available CPU. The default value should be appropriate for all sized VMs.

These new settings have been tested on pods ranging from 0.6 to 8 available CPU.