### PR TITLE
Bump common-streams to 0.10.0

### DIFF
--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -43,6 +43,11 @@
     # -- Allows bigger instances to more quickly acquire the shard-leases they need to combat latency
     "maxLeasesToStealAtOneTimeFactor": 2.0
 
+    # -- Configures how to backoff and retry in case of DynamoDB provisioned throughput limits
+    "checkpointThrottledBackoffPolicy": {
+      "minBackoff": "100 millis"
+      "maxBackoff": "1 second"
+    }
   }
 
   "output": {

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -12,22 +12,21 @@
     # -- The number of threads is equal to this factor multiplied by the number of availble cpu cores
     "parallelPullFactor": 0.5
 
-    # -- How many bytes can be buffered by the loader app before blocking the pubsub client library
-    # -- from fetching more events.
-    # -- This is a balance between memory usage vs how efficiently the app can operate.  The default value works well.
-    "bufferMaxBytes": 1000000
+    # -- Pubsub ack deadlines are extended for this duration when needed.
+    "durationPerAckExtension": "60 seconds"
 
-    # -- For how long the pubsub client library will continue to re-extend the ack deadline of an unprocessed event.
-    "maxAckExtensionPeriod": "1 hour"
+    # -- Controls when ack deadlines are re-extended, for a message that is close to exceeding its ack deadline.
+    # -- For example, if `durationPerAckExtension` is `60 seconds` and `minRemainingAckDeadline` is `0.1` then the Source
+    # -- will wait until there is `6 seconds` left of the remining deadline, before re-extending the message deadline.
+    "minRemainingAckDeadline": 0.1
 
-    # -- Sets min/max boundaries on the value by which an ack deadline is extended.
-    # -- The actual value used is guided by runtime statistics collected by the pubsub client library.
-    "minDurationPerAckExtension": "60 seconds"
-    "maxDurationPerAckExtension": "600 seconds"
+    # -- How many pubsub messages to pull from the server in a single request.
+    "maxMessagesPerPull": 1000
 
-    # -- The maximum number of streaming pulls we allow on a single GRPC transport channel before opening another channel.
-    # -- This advanced setting is only relevant on extremely large VMs, or with a high value of `parallelPullCount`.
-    "maxPullsPerTransportChannel": 16
+    # -- Adds an artifical delay between consecutive requests to pubsub for more messages.
+    # -- Under some circumstances, this was found to slightly alleviate a problem in which pubsub might re-deliver
+    # -- the same messages multiple times.
+    "debounceRequests": "100 millis"
   }
 
   "output": {

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Environment.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Environment.scala
@@ -61,7 +61,7 @@ object Environment {
       _ <- HealthProbe.resource(config.monitoring.healthProbe.port, appHealth)
       _ <- Webhook.resource(config.monitoring.webhook, appInfo, httpClient, appHealth)
       badSink <- toSink(config.output.bad.sink).onError(_ => Resource.eval(appHealth.beUnhealthyForRuntimeService(RuntimeService.BadSink)))
-      metrics <- Resource.eval(Metrics.build(config.monitoring.metrics))
+      metrics <- Resource.eval(Metrics.build(config.monitoring.metrics, sourceAndAck))
       tableManager <- Resource.eval(TableManager.make(config.output.good, appHealth, config.retries))
       cpuParallelism    = chooseCpuParallelism(config)
       uploadParallelism = chooseUploadParallelism(config)

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Metrics.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Metrics.scala
@@ -10,51 +10,62 @@
 
 package com.snowplowanalytics.snowplow.snowflake
 
+import cats.Functor
 import cats.effect.Async
 import cats.effect.kernel.Ref
 import cats.implicits._
 import fs2.Stream
 
+import com.snowplowanalytics.snowplow.sources.SourceAndAck
 import com.snowplowanalytics.snowplow.runtime.{Metrics => CommonMetrics}
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 trait Metrics[F[_]] {
   def addGood(count: Int): F[Unit]
   def addBad(count: Int): F[Unit]
-  def setLatencyMillis(latencyMillis: Long): F[Unit]
+  def setLatency(latency: FiniteDuration): F[Unit]
 
   def report: Stream[F, Nothing]
 }
 
 object Metrics {
 
-  def build[F[_]: Async](config: Config.Metrics): F[Metrics[F]] =
-    Ref[F].of(State.empty).map(impl(config, _))
+  def build[F[_]: Async](config: Config.Metrics, sourceAndAck: SourceAndAck[F]): F[Metrics[F]] =
+    Ref.ofEffect(State.initialize(sourceAndAck)).map(impl(config, _, sourceAndAck))
 
   private case class State(
     good: Int,
     bad: Int,
-    latencyMillis: Long
+    latency: FiniteDuration
   ) extends CommonMetrics.State {
     def toKVMetrics: List[CommonMetrics.KVMetric] =
       List(
         KVMetric.CountGood(good),
         KVMetric.CountBad(bad),
-        KVMetric.LatencyMillis(latencyMillis)
+        KVMetric.Latency(latency)
       )
   }
 
   private object State {
-    def empty: State = State(0, 0, 0L)
+    def initialize[F[_]: Functor](sourceAndAck: SourceAndAck[F]): F[State] =
+      sourceAndAck.currentStreamLatency.map { latency =>
+        State(0, 0, latency.getOrElse(Duration.Zero))
+      }
   }
 
-  private def impl[F[_]: Async](config: Config.Metrics, ref: Ref[F, State]): Metrics[F] =
-    new CommonMetrics[F, State](ref, State.empty, config.statsd) with Metrics[F] {
+  private def impl[F[_]: Async](
+    config: Config.Metrics,
+    ref: Ref[F, State],
+    sourceAndAck: SourceAndAck[F]
+  ): Metrics[F] =
+    new CommonMetrics[F, State](ref, State.initialize(sourceAndAck), config.statsd) with Metrics[F] {
       def addGood(count: Int): F[Unit] =
         ref.update(s => s.copy(good = s.good + count))
       def addBad(count: Int): F[Unit] =
         ref.update(s => s.copy(bad = s.bad + count))
-      def setLatencyMillis(latencyMillis: Long): F[Unit] =
-        ref.update(s => s.copy(latencyMillis = s.latencyMillis.max(latencyMillis)))
+      def setLatency(latency: FiniteDuration): F[Unit] =
+        ref.update(s => s.copy(latency = s.latency.max(latency)))
     }
 
   private object KVMetric {
@@ -71,9 +82,9 @@ object Metrics {
       val metricType = CommonMetrics.MetricType.Count
     }
 
-    final case class LatencyMillis(v: Long) extends CommonMetrics.KVMetric {
+    final case class Latency(v: FiniteDuration) extends CommonMetrics.KVMetric {
       val key        = "latency_millis"
-      val value      = v.toString
+      val value      = v.toMillis.toString
       val metricType = CommonMetrics.MetricType.Gauge
     }
 

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
@@ -17,9 +17,10 @@ import com.comcast.ip4s.Port
 import com.snowplowanalytics.iglu.core.SchemaCriterion
 import com.snowplowanalytics.snowplow.runtime.Metrics.StatsdConfig
 import com.snowplowanalytics.snowplow.runtime.{AcceptedLicense, ConfigParser, HttpClient, Retrying, Telemetry, Webhook}
-import com.snowplowanalytics.snowplow.sinks.kinesis.{BackoffPolicy, KinesisSinkConfig}
+import com.snowplowanalytics.snowplow.sinks.kinesis.KinesisSinkConfig
 import com.snowplowanalytics.snowplow.snowflake.Config.Snowflake
 import com.snowplowanalytics.snowplow.sources.kinesis.KinesisSourceConfig
+import com.snowplowanalytics.snowplow.kinesis.BackoffPolicy
 import org.http4s.implicits.http4sLiteralsSyntax
 import org.specs2.Specification
 
@@ -61,16 +62,17 @@ class KinesisConfigSpec extends Specification with CatsEffect {
 object KinesisConfigSpec {
   private val minimalConfig = Config[KinesisSourceConfig, KinesisSinkConfig](
     input = KinesisSourceConfig(
-      appName                         = "snowplow-snowflake-loader",
-      streamName                      = "snowplow-enriched-events",
-      workerIdentifier                = "testWorkerId",
-      initialPosition                 = KinesisSourceConfig.InitialPosition.Latest,
-      retrievalMode                   = KinesisSourceConfig.Retrieval.Polling(1000),
-      customEndpoint                  = None,
-      dynamodbCustomEndpoint          = None,
-      cloudwatchCustomEndpoint        = None,
-      leaseDuration                   = 10.seconds,
-      maxLeasesToStealAtOneTimeFactor = BigDecimal(2.0)
+      appName                          = "snowplow-snowflake-loader",
+      streamName                       = "snowplow-enriched-events",
+      workerIdentifier                 = "testWorkerId",
+      initialPosition                  = KinesisSourceConfig.InitialPosition.Latest,
+      retrievalMode                    = KinesisSourceConfig.Retrieval.Polling(1000),
+      customEndpoint                   = None,
+      dynamodbCustomEndpoint           = None,
+      cloudwatchCustomEndpoint         = None,
+      leaseDuration                    = 10.seconds,
+      maxLeasesToStealAtOneTimeFactor  = BigDecimal(2.0),
+      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second)
     ),
     output = Config.Output(
       good = Config.Snowflake(
@@ -93,7 +95,7 @@ object KinesisConfigSpec {
       bad = Config.SinkWithMaxSize(
         sink = KinesisSinkConfig(
           streamName             = "bad",
-          throttledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second, maxRetries = None),
+          throttledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
           recordLimit            = 500,
           byteLimit              = 5242880,
           customEndpoint         = None
@@ -139,16 +141,17 @@ object KinesisConfigSpec {
    */
   private val extendedConfig = Config[KinesisSourceConfig, KinesisSinkConfig](
     input = KinesisSourceConfig(
-      appName                         = "snowplow-snowflake-loader",
-      streamName                      = "snowplow-enriched-events",
-      workerIdentifier                = "testWorkerId",
-      initialPosition                 = KinesisSourceConfig.InitialPosition.TrimHorizon,
-      retrievalMode                   = KinesisSourceConfig.Retrieval.Polling(1000),
-      customEndpoint                  = None,
-      dynamodbCustomEndpoint          = None,
-      cloudwatchCustomEndpoint        = None,
-      leaseDuration                   = 10.seconds,
-      maxLeasesToStealAtOneTimeFactor = BigDecimal(2.0)
+      appName                          = "snowplow-snowflake-loader",
+      streamName                       = "snowplow-enriched-events",
+      workerIdentifier                 = "testWorkerId",
+      initialPosition                  = KinesisSourceConfig.InitialPosition.TrimHorizon,
+      retrievalMode                    = KinesisSourceConfig.Retrieval.Polling(1000),
+      customEndpoint                   = None,
+      dynamodbCustomEndpoint           = None,
+      cloudwatchCustomEndpoint         = None,
+      leaseDuration                    = 10.seconds,
+      maxLeasesToStealAtOneTimeFactor  = BigDecimal(2.0),
+      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second)
     ),
     output = Config.Output(
       good = Config.Snowflake(
@@ -171,7 +174,7 @@ object KinesisConfigSpec {
       bad = Config.SinkWithMaxSize(
         sink = KinesisSinkConfig(
           streamName             = "bad",
-          throttledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second, maxRetries = None),
+          throttledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
           recordLimit            = 500,
           byteLimit              = 5242880,
           customEndpoint         = None

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
@@ -62,15 +62,13 @@ class PubsubConfigSpec extends Specification with CatsEffect {
 object PubsubConfigSpec {
   private val minimalConfig = Config[PubsubSourceConfig, PubsubSinkConfig](
     input = PubsubSourceConfig(
-      subscription                = PubsubSourceConfig.Subscription("myproject", "snowplow-enriched"),
-      parallelPullFactor          = 0.5,
-      bufferMaxBytes              = 10000000,
-      maxAckExtensionPeriod       = 1.hour,
-      minDurationPerAckExtension  = 1.minute,
-      maxDurationPerAckExtension  = 10.minutes,
-      gcpUserAgent                = GcpUserAgent("Snowplow OSS", "snowflake-loader"),
-      shutdownTimeout             = 30.seconds,
-      maxPullsPerTransportChannel = 16
+      subscription            = PubsubSourceConfig.Subscription("myproject", "snowplow-enriched"),
+      parallelPullFactor      = 0.5,
+      durationPerAckExtension = 60.seconds,
+      minRemainingAckDeadline = 0.1,
+      maxMessagesPerPull      = 1000,
+      debounceRequests        = 100.millis,
+      gcpUserAgent            = GcpUserAgent("Snowplow OSS", "snowflake-loader")
     ),
     output = Config.Output(
       good = Config.Snowflake(
@@ -138,15 +136,13 @@ object PubsubConfigSpec {
    */
   private val extendedConfig = Config[PubsubSourceConfig, PubsubSinkConfig](
     input = PubsubSourceConfig(
-      subscription                = PubsubSourceConfig.Subscription("myproject", "snowplow-enriched"),
-      parallelPullFactor          = 0.5,
-      bufferMaxBytes              = 1000000,
-      maxAckExtensionPeriod       = 1.hour,
-      minDurationPerAckExtension  = 1.minute,
-      maxDurationPerAckExtension  = 10.minutes,
-      gcpUserAgent                = GcpUserAgent("Snowplow OSS", "snowflake-loader"),
-      shutdownTimeout             = 30.seconds,
-      maxPullsPerTransportChannel = 16
+      subscription            = PubsubSourceConfig.Subscription("myproject", "snowplow-enriched"),
+      parallelPullFactor      = 0.5,
+      durationPerAckExtension = 60.seconds,
+      minRemainingAckDeadline = 0.1,
+      maxMessagesPerPull      = 1000,
+      debounceRequests        = 100.millis,
+      gcpUserAgent            = GcpUserAgent("Snowplow OSS", "snowflake-loader")
     ),
     output = Config.Output(
       good = Config.Snowflake(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
     val sentry    = "6.25.2"
     val snowflake = "3.0.0"
     val jaxb      = "2.3.1"
-    val awsSdk2   = "2.25.16"
+    val awsSdk2   = "2.29.0"
     val netty     = "4.1.100.Final" // Version override
     val reactor   = "1.0.39" // Version override
     val snappy    = "1.1.10.4" // Version override
@@ -35,7 +35,7 @@ object Dependencies {
     val protobuf  = "3.25.5" // Version override
 
     // Snowplow
-    val streams = "0.9.0"
+    val streams = "0.10.0"
 
     // tests
     val specs2           = "4.20.0"


### PR DESCRIPTION
Jira ref: PDP-1683

Common streams 0.10.0 brings significant to changes to the Kinesis and Pubsub sources:

- PubSub source completely re-written to be a wrapper around UnaryPull snowplow-incubator/common-streams#101
- Kinesis source is more efficient when the stream is re-sharded snowplow-incubator/common-streams#102
- Kinesis source better tuned for larger deployments snowplow-incubator/common-streams#99

And improvements to latency metrics:
- Sources should report stream latency of stuck events snowplow-incubator/common-streams#104