### PR TITLE
Bump common-streams to 0.11.0

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -11,6 +11,10 @@
     # -- kafka bootstrap servers
     "bootstrapServers": "localhost:9092"
 
+    # -- How frequently to commit our progress back to kafka. By increasing this value,
+    # -- we decrease the number of requests made to the kafka broker
+    debounceCommitOffsets: "10 seconds"
+
     # -- Any valid Kafka consumer config options
     consumerConf: {
       "group.id": "snowplow-snowflake-loader"

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -48,6 +48,10 @@
       "minBackoff": "100 millis"
       "maxBackoff": "1 second"
     }
+
+    ## -- How frequently to checkpoint our progress to the DynamoDB table. By increasing this value,
+    ## -- we can decrease the write-throughput requirements of the DynamoDB table
+    debounceCheckpoints: "10 seconds"
   }
 
   "output": {

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
@@ -61,8 +61,9 @@ class KafkaConfigSpec extends Specification with CatsEffect {
 object KafkaConfigSpec {
   private val minimalConfig = Config[KafkaSourceConfig, KafkaSinkConfig](
     input = KafkaSourceConfig(
-      topicName        = "sp-dev-enriched",
-      bootstrapServers = "localhost:9092",
+      topicName             = "sp-dev-enriched",
+      bootstrapServers      = "localhost:9092",
+      debounceCommitOffsets = 10.seconds,
       consumerConf = Map(
         "group.id" -> "snowplow-snowflake-loader",
         "allow.auto.create.topics" -> "false",
@@ -142,8 +143,9 @@ object KafkaConfigSpec {
    */
   private val extendedConfig = Config[KafkaSourceConfig, KafkaSinkConfig](
     input = KafkaSourceConfig(
-      topicName        = "sp-dev-enriched",
-      bootstrapServers = "localhost:9092",
+      topicName             = "sp-dev-enriched",
+      bootstrapServers      = "localhost:9092",
+      debounceCommitOffsets = 10.seconds,
       consumerConf = Map(
         "group.id" -> "snowplow-snowflake-loader",
         "enable.auto.commit" -> "false",

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
@@ -72,7 +72,8 @@ object KinesisConfigSpec {
       cloudwatchCustomEndpoint         = None,
       leaseDuration                    = 10.seconds,
       maxLeasesToStealAtOneTimeFactor  = BigDecimal(2.0),
-      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second)
+      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
+      debounceCheckpoints              = 10.seconds
     ),
     output = Config.Output(
       good = Config.Snowflake(
@@ -151,7 +152,8 @@ object KinesisConfigSpec {
       cloudwatchCustomEndpoint         = None,
       leaseDuration                    = 10.seconds,
       maxLeasesToStealAtOneTimeFactor  = BigDecimal(2.0),
-      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second)
+      checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
+      debounceCheckpoints              = 10.seconds
     ),
     output = Config.Output(
       good = Config.Snowflake(

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -60,6 +60,13 @@ object BuildSettings {
       "SNOWFLAKE_PRIVATE_KEY" -> "secretPrivateKey",
       "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE" -> "secretKeyPassphrase",
       "HOSTNAME" -> "testWorkerId"
+    ),
+    libraryDependencySchemes ++= Seq(
+      // kafka-clients uses version 1.5.6-4, snowflake-ingest-sdk uses version 1.5.0-1 of zstd-jni.
+      // SBT reports version conflict between these two versions however this is a Java library and
+      // doesn't follow Early Semver version scheme that is recommended for Scala libraries.
+      // Therefore, version conflict reports for this library are ignored.
+      "com.github.luben" % "zstd-jni" % VersionScheme.Always
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,11 +22,11 @@ object Dependencies {
 
     // java
     val slf4j     = "2.0.7"
-    val azureSdk  = "1.9.1"
+    val azureSdk  = "1.15.1"
     val sentry    = "6.25.2"
     val snowflake = "3.0.0"
     val jaxb      = "2.3.1"
-    val awsSdk2   = "2.29.0"
+    val awsSdk2   = "2.30.17"
     val netty     = "4.1.100.Final" // Version override
     val reactor   = "1.0.39" // Version override
     val snappy    = "1.1.10.4" // Version override
@@ -35,7 +35,7 @@ object Dependencies {
     val protobuf  = "3.25.5" // Version override
 
     // Snowplow
-    val streams = "0.10.0"
+    val streams = "0.11.0"
 
     // tests
     val specs2           = "4.20.0"


### PR DESCRIPTION
Jira ref: PDP-1686

common-streams 0.11.0 brings:

- Debounce how often we checkpoint progress. It allows to decrease the write-throughput requirements of the DynamoDB table for kinesis source and decrease the number of requests made to the kafka broker for kafka source. Checkpoint batching in Snowflake Loader is removed since it is implemented in common-streams. https://github.com/snowplow-incubator/common-streams/pull/109
- Prefetch from pubsub source when parallelPullCount is 1. This means the pubsub source behaves more consistently across different parallelisms, and more similar to the other sources. https://github.com/snowplow-incubator/common-streams/pull/110
- Dependencies upgrades https://github.com/snowplow-incubator/common-streams/pull/112