### PR TITLE
Add e2e_latency_millis metric

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Metrics.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Metrics.scala
@@ -25,6 +25,7 @@ trait Metrics[F[_]] {
   def addGood(count: Int): F[Unit]
   def addBad(count: Int): F[Unit]
   def setLatency(latency: FiniteDuration): F[Unit]
+  def setE2ELatency(e2eLatency: FiniteDuration): F[Unit]
 
   def report: Stream[F, Nothing]
 }
@@ -37,20 +38,21 @@ object Metrics {
   private case class State(
     good: Int,
     bad: Int,
-    latency: FiniteDuration
+    latency: FiniteDuration,
+    e2eLatency: Option[FiniteDuration]
   ) extends CommonMetrics.State {
     def toKVMetrics: List[CommonMetrics.KVMetric] =
       List(
         KVMetric.CountGood(good),
         KVMetric.CountBad(bad),
         KVMetric.Latency(latency)
-      )
+      ) ++ e2eLatency.map(KVMetric.E2ELatency(_))
   }
 
   private object State {
     def initialize[F[_]: Functor](sourceAndAck: SourceAndAck[F]): F[State] =
       sourceAndAck.currentStreamLatency.map { latency =>
-        State(0, 0, latency.getOrElse(Duration.Zero))
+        State(0, 0, latency.getOrElse(Duration.Zero), None)
       }
   }
 
@@ -66,6 +68,11 @@ object Metrics {
         ref.update(s => s.copy(bad = s.bad + count))
       def setLatency(latency: FiniteDuration): F[Unit] =
         ref.update(s => s.copy(latency = s.latency.max(latency)))
+      def setE2ELatency(e2eLatency: FiniteDuration): F[Unit] =
+        ref.update { state =>
+          val newLatency = state.e2eLatency.fold(e2eLatency)(_.max(e2eLatency))
+          state.copy(e2eLatency = Some(newLatency))
+        }
     }
 
   private object KVMetric {
@@ -84,6 +91,12 @@ object Metrics {
 
     final case class Latency(v: FiniteDuration) extends CommonMetrics.KVMetric {
       val key        = "latency_millis"
+      val value      = v.toMillis.toString
+      val metricType = CommonMetrics.MetricType.Gauge
+    }
+
+    final case class E2ELatency(v: FiniteDuration) extends CommonMetrics.KVMetric {
+      val key        = "e2e_latency_millis"
       val value      = v.toMillis.toString
       val metricType = CommonMetrics.MetricType.Gauge
     }

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/MockEnvironment.scala
@@ -38,6 +38,7 @@ object MockEnvironment {
     case class AddedGoodCountMetric(count: Int) extends Action
     case class AddedBadCountMetric(count: Int) extends Action
     case class SetLatencyMetric(latency: FiniteDuration) extends Action
+    case class SetE2ELatencyMetric(e2eLatency: FiniteDuration) extends Action
     case class BecameUnhealthy(service: RuntimeService) extends Action
     case class BecameHealthy(service: RuntimeService) extends Action
   }
@@ -182,6 +183,9 @@ object MockEnvironment {
 
     def setLatency(latency: FiniteDuration): IO[Unit] =
       ref.update(_ :+ SetLatencyMetric(latency))
+
+    def setE2ELatency(e2eLatency: FiniteDuration): IO[Unit] =
+      ref.update(_ :+ SetE2ELatencyMetric(e2eLatency))
 
     def report: Stream[IO, Nothing] = Stream.never[IO]
   }


### PR DESCRIPTION
Jira ref: PDP-1684

This PR adds a new metric `e2e_latency_millis` which measures the difference between an event's `collector_tstamp` and when it was written to Snowflake.

The metric is emitted to statsd only on minutes in which some events are written to Snowflake. 

The metric measures the worst-case latency for a batch, i.e. latency for the earliest seen `collector_tstamp`.