### PR TITLE
[PDP-1688] Update error message for misconfigured network rules

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeRetrying.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeRetrying.scala
@@ -45,7 +45,7 @@ object SnowflakeRetrying {
       // Snowflake returns a 513 HTTP status code if you try to connect to a host that does not exist
       "Unrecognized Snowflake account name or host name"
     case _: SecurityException =>
-      "Unauthorized: Invalid user name or public/private key pair"
+      "Unauthorized: Invalid user name or invalid public/private key pair or mis-configured network policies"
     case sql: java.sql.SQLException if Set(2003, 2043).contains(sql.getErrorCode) =>
       // Various known error codes for object does not exist or not authorized to view it
       sql.show


### PR DESCRIPTION
Sadly the exception in case of misconfigured network rules is indistinguishable from the exception we get when the username/key is wrong.
The error message should contain all possible issues.