### PR TITLE
Include rc tags for snyk scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
         run: sbt "project ${{ matrix.app }}Distroless" docker:publishLocal
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/docker@master
-        if: ${{ !contains(github.ref_name, 'rc') }}
         with:
           image: "snowplow/snowflake-loader-${{ matrix.app }}:${{ github.ref_name }}-distroless"
           args: "--app-vulns --org=data-processing-new"


### PR DESCRIPTION
Excluding rc tags led to hitting issues with snyk integration only when final release is cut. Including rc tags could help us discover such cases earlier.