### PR TITLE
Add setup alert for no privileges on events table

### DIFF
--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeRetrying.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/SnowflakeRetrying.scala
@@ -15,7 +15,6 @@ import cats.effect.Sync
 import cats.implicits._
 import retry._
 import net.snowflake.ingest.connection.IngestResponseException
-import net.snowflake.client.jdbc.SnowflakeSQLException
 
 import java.lang.SecurityException
 import scala.util.matching.Regex


### PR DESCRIPTION
This PR extends setup alert mechanism by adding a new error code check for `3041`, one of authorization error codes from snowflake.

An example exception for error code 3041 is as following:

```
net.snowflake.client.jdbc.SnowflakeSQLException: SQL compilation error:
Table 'EVENTS' already exists, but current role has no privileges on it. If this is unexpected and you cannot resolve this problem, contact your system administrator. ACCOUNTADMIN role may be required to manage the privileges on the object.
```

and the alert message will be

```
Table 'EVENTS' already exists, but current role has no privileges on it. If this is unexpected and you cannot resolve this problem, contact your system administrator. ACCOUNTADMIN role may be required to manage the privileges on the object.
```

ref: [pdp-1792](https://snplow.atlassian.net/browse/PDP-1792)