### PR TITLE
Use offset tokens to ensure at-least-once semantics

### DIFF
--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -87,9 +87,9 @@
     "maxDelay": "1 second"
 
     # - Controls how many batches can we send simultaneously over the network to Snowflake.
-    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 3.5, then we send up to 14 batches in parallel
     # -- Adjusting this value can cause the app to use more or less of the available CPU.
-    "uploadParallelismFactor":  2.5
+    "uploadParallelismFactor":  3.5
   }
 
   # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.

--- a/config/config.azure.reference.hocon
+++ b/config/config.azure.reference.hocon
@@ -107,11 +107,17 @@
       "delay": "30 seconds"
     }
 
-    # -- Configures exponential backoff  errors that are likely to be transient.
+    # -- Configures exponential backoff errors that are likely to be transient.
     # -- Examples include server errors and network errors
     "transientErrors": {
       "delay": "1 second"
       "attempts": 5
+    }
+
+    # -- Configures a delay in between flushing events to snowflake and fetching the latest offset
+    # -- token from snowflake to check the events are fully ingested.
+    "checkCommittedOffset": {
+      "delay": "100 millis"
     }
   }
 

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -140,11 +140,17 @@
       "delay": "30 seconds"
     }
 
-    # -- Configures exponential backoff  errors that are likely to be transient.
+    # -- Configures exponential backoff errors that are likely to be transient.
     # -- Examples include server errors and network errors
     "transientErrors": {
       "delay": "1 second"
       "attempts": 5
+    }
+
+    # -- Configures a delay in between flushing events to snowflake and fetching the latest offset
+    # -- token from snowflake to check the events are fully ingested.
+    "checkCommittedOffset": {
+      "delay": "100 millis"
     }
   }
 

--- a/config/config.kinesis.reference.hocon
+++ b/config/config.kinesis.reference.hocon
@@ -120,9 +120,9 @@
     "maxDelay": "1 second"
 
     # - Controls how many batches can we send simultaneously over the network to Snowflake.
-    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 3.5, then we send up to 14 batches in parallel
     # -- Adjusting this value can cause the app to use more or less of the available CPU.
-    "uploadParallelismFactor":  2.5
+    "uploadParallelismFactor":  3.5
   }
 
   # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -108,11 +108,17 @@
       "delay": "30 seconds"
     }
 
-    # -- Configures exponential backoff  errors that are likely to be transient.
+    # -- Configures exponential backoff errors that are likely to be transient.
     # -- Examples include server errors and network errors
     "transientErrors": {
       "delay": "1 second"
       "attempts": 5
+    }
+
+    # -- Configures a delay in between flushing events to snowflake and fetching the latest offset
+    # -- token from snowflake to check the events are fully ingested.
+    "checkCommittedOffset": {
+      "delay": "100 millis"
     }
   }
 

--- a/config/config.pubsub.reference.hocon
+++ b/config/config.pubsub.reference.hocon
@@ -88,9 +88,9 @@
     "maxDelay": "1 second"
 
     # - Controls how many batches can we send simultaneously over the network to Snowflake.
-    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 2.5, then we send up to 10 batches in parallel
+    # -- E.g. If there are 4 available processors, and uploadParallelismFactor = 3.5, then we send up to 14 batches in parallel
     # -- Adjusting this value can cause the app to use more or less of the available CPU.
-    "uploadParallelismFactor":  2.5
+    "uploadParallelismFactor":  3.5
   }
 
   # -- Controls how the app splits the workload into concurrent batches which can be run in parallel.

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -26,7 +26,7 @@
   "batching": {
     "maxBytes": 16000000
     "maxDelay": "1 second"
-    "uploadParallelismFactor":  2.5
+    "uploadParallelismFactor":  3.5
   }
   "cpuParallelismFactor": 0.75
 

--- a/modules/core/src/main/resources/reference.conf
+++ b/modules/core/src/main/resources/reference.conf
@@ -38,6 +38,9 @@
       "delay": "1 second"
       "attempts": 5
     }
+    "checkCommittedOffset": {
+      "delay": "100 millis"
+    }
   }
 
   "skipSchemas": []

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Config.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/Config.scala
@@ -94,12 +94,12 @@ object Config {
     webhook: Webhook.Config
   )
 
-  case class SetupErrorRetries(delay: FiniteDuration)
-  case class TransientErrorRetries(delay: FiniteDuration, attempts: Int)
+  case class CheckCommittedOffsetRetries(delay: FiniteDuration)
 
   case class Retries(
     setupErrors: Retrying.Config.ForSetup,
-    transientErrors: Retrying.Config.ForTransient
+    transientErrors: Retrying.Config.ForTransient,
+    checkCommittedOffset: CheckCommittedOffsetRetries
   )
 
   case class Http(client: HttpClient.Config)
@@ -126,11 +126,12 @@ object Config {
         case SentryM(None, _) =>
           None
       }
-    implicit val metricsDecoder     = deriveConfiguredDecoder[Metrics]
-    implicit val healthProbeDecoder = deriveConfiguredDecoder[HealthProbe]
-    implicit val monitoringDecoder  = deriveConfiguredDecoder[Monitoring]
-    implicit val retriesDecoder     = deriveConfiguredDecoder[Retries]
-    implicit val httpDecoder        = deriveConfiguredDecoder[Http]
+    implicit val metricsDecoder                = deriveConfiguredDecoder[Metrics]
+    implicit val healthProbeDecoder            = deriveConfiguredDecoder[HealthProbe]
+    implicit val monitoringDecoder             = deriveConfiguredDecoder[Monitoring]
+    implicit val committedOffsetRetriesDecoder = deriveConfiguredDecoder[CheckCommittedOffsetRetries]
+    implicit val retriesDecoder                = deriveConfiguredDecoder[Retries]
+    implicit val httpDecoder                   = deriveConfiguredDecoder[Http]
     implicit val licenseDecoder =
       AcceptedLicense.decoder(AcceptedLicense.DocumentationLink("https://docs.snowplow.io/limited-use-license-1.1/"))
     deriveConfiguredDecoder[Config[Source, Sink]]

--- a/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Channel.scala
+++ b/modules/core/src/main/scala/com.snowplowanalytics.snowplow.snowflake/processing/Channel.scala
@@ -109,7 +109,7 @@ object Channel {
     for {
       client <- createClient(config, retriesConfig, appHealth)
     } yield new Opener[F] {
-      def open: F[CloseableChannel[F]] = createChannel[F](config, client, index).map(impl[F])
+      def open: F[CloseableChannel[F]] = createChannel[F](config, client, index).map(impl[F](retriesConfig.checkCommittedOffset, _))
     }
 
   def provider[F[_]: Async](
@@ -134,15 +134,16 @@ object Channel {
     Resource.makeFull(make)(_.close)
   }
 
-  private def impl[F[_]: Async](channel: SnowflakeStreamingIngestChannel): CloseableChannel[F] =
+  private def impl[F[_]: Async](config: Config.CheckCommittedOffsetRetries, channel: SnowflakeStreamingIngestChannel): CloseableChannel[F] =
     new CloseableChannel[F] {
 
       def write(rows: Iterable[Map[String, AnyRef]]): F[WriteResult] = {
         val attempt: F[WriteResult] = for {
-          response <- Sync[F].blocking(channel.insertRows(rows.map(_.asJava).asJava, null))
+          offsetToken <- Sync[F].monotonic.map(_.toNanos.toString)
+          response <- Sync[F].blocking(channel.insertRows(rows.map(_.asJava).asJava, offsetToken.toString))
           _ <- flushChannel[F](channel)
-          isValid <- Sync[F].delay(channel.isValid)
-        } yield if (isValid) WriteResult.WriteFailures(parseResponse(response)) else WriteResult.ChannelIsInvalid
+          _ <- waitForOffsetToken(config, channel, offsetToken)
+        } yield WriteResult.WriteFailures(parseResponse(response))
 
         attempt.recover {
           case sfe: SFException if sfe.getVendorCode === SFErrorCode.INVALID_CHANNEL.getMessageCode =>
@@ -164,6 +165,18 @@ object Channel {
                 // We have already handled errors associated with invalid channel
                 ()
             }
+    }
+
+  private def waitForOffsetToken[F[_]: Async](
+    config: Config.CheckCommittedOffsetRetries,
+    channel: SnowflakeStreamingIngestChannel,
+    offsetToken: String
+  ): F[Unit] =
+    Sync[F].untilDefinedM {
+      for {
+        _ <- Async[F].sleep(config.delay)
+        committedOffsetToken <- Sync[F].blocking(channel.getLatestCommittedOffsetToken())
+      } yield if (committedOffsetToken === offsetToken) Some(()) else None
     }
 
   private def parseResponse(response: InsertValidationResponse): List[WriteFailure] =

--- a/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/processing/ChannelProviderSpec.scala
+++ b/modules/core/src/test/scala/com.snowplowanalytics.snowplow.snowflake/processing/ChannelProviderSpec.scala
@@ -282,7 +282,11 @@ object ChannelProviderSpec {
     appHealth: AppHealth.Interface[IO, Alert, RuntimeService]
   )
 
-  def retriesConfig = Config.Retries(Retrying.Config.ForSetup(30.seconds), Retrying.Config.ForTransient(1.second, 5))
+  def retriesConfig = Config.Retries(
+    Retrying.Config.ForSetup(30.seconds),
+    Retrying.Config.ForTransient(1.second, 5),
+    Config.CheckCommittedOffsetRetries(100.millis)
+  )
 
   def control: IO[Control] =
     for {

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
@@ -112,8 +112,9 @@ object KafkaConfigSpec {
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
-      setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
-      transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
+      setupErrors          = Retrying.Config.ForSetup(delay = 30.seconds),
+      transientErrors      = Retrying.Config.ForTransient(delay = 1.second, attempts = 5),
+      checkCommittedOffset = Config.CheckCommittedOffsetRetries(delay = 100.millis)
     ),
     skipSchemas = List.empty,
     telemetry = Telemetry.Config(
@@ -195,8 +196,9 @@ object KafkaConfigSpec {
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
-      setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
-      transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
+      setupErrors          = Retrying.Config.ForSetup(delay = 30.seconds),
+      transientErrors      = Retrying.Config.ForTransient(delay = 1.second, attempts = 5),
+      checkCommittedOffset = Config.CheckCommittedOffsetRetries(delay = 100.millis)
     ),
     skipSchemas = List(
       SchemaCriterion.parse("iglu:com.acme/skipped1/jsonschema/1-0-0").get,

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KafkaConfigSpec.scala
@@ -108,7 +108,7 @@ object KafkaConfigSpec {
     batching = Config.Batching(
       maxBytes                = 16000000,
       maxDelay                = 1.second,
-      uploadParallelismFactor = BigDecimal(2.5)
+      uploadParallelismFactor = BigDecimal(3.5)
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
@@ -192,7 +192,7 @@ object KafkaConfigSpec {
     batching = Config.Batching(
       maxBytes                = 16000000,
       maxDelay                = 1.second,
-      uploadParallelismFactor = BigDecimal(2.5)
+      uploadParallelismFactor = BigDecimal(3.5)
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
@@ -107,7 +107,7 @@ object KinesisConfigSpec {
     batching = Config.Batching(
       maxBytes                = 16000000,
       maxDelay                = 1.second,
-      uploadParallelismFactor = BigDecimal(2.5)
+      uploadParallelismFactor = BigDecimal(3.5)
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
@@ -188,7 +188,7 @@ object KinesisConfigSpec {
     batching = Config.Batching(
       maxBytes                = 16000000,
       maxDelay                = 1.second,
-      uploadParallelismFactor = BigDecimal(2.5)
+      uploadParallelismFactor = BigDecimal(3.5)
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/snowflake/KinesisConfigSpec.scala
@@ -111,8 +111,9 @@ object KinesisConfigSpec {
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
-      setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
-      transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
+      setupErrors          = Retrying.Config.ForSetup(delay = 30.seconds),
+      transientErrors      = Retrying.Config.ForTransient(delay = 1.second, attempts = 5),
+      checkCommittedOffset = Config.CheckCommittedOffsetRetries(delay = 100.millis)
     ),
     skipSchemas = List.empty,
     telemetry = Telemetry.Config(
@@ -191,8 +192,9 @@ object KinesisConfigSpec {
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
-      setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
-      transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
+      setupErrors          = Retrying.Config.ForSetup(delay = 30.seconds),
+      transientErrors      = Retrying.Config.ForTransient(delay = 1.second, attempts = 5),
+      checkCommittedOffset = Config.CheckCommittedOffsetRetries(delay = 100.millis)
     ),
     skipSchemas = List(
       SchemaCriterion.parse("iglu:com.acme/skipped1/jsonschema/1-0-0").get,

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
@@ -101,7 +101,7 @@ object PubsubConfigSpec {
     batching = Config.Batching(
       maxBytes                = 16000000,
       maxDelay                = 1.second,
-      uploadParallelismFactor = BigDecimal(2.5)
+      uploadParallelismFactor = BigDecimal(3.5)
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
@@ -176,7 +176,7 @@ object PubsubConfigSpec {
     batching = Config.Batching(
       maxBytes                = 16000000,
       maxDelay                = 1.second,
-      uploadParallelismFactor = BigDecimal(2.5)
+      uploadParallelismFactor = BigDecimal(3.5)
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/snowflake/PubsubConfigSpec.scala
@@ -105,8 +105,9 @@ object PubsubConfigSpec {
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
-      setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
-      transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
+      setupErrors          = Retrying.Config.ForSetup(delay = 30.seconds),
+      transientErrors      = Retrying.Config.ForTransient(delay = 1.second, attempts = 5),
+      checkCommittedOffset = Config.CheckCommittedOffsetRetries(delay = 100.millis)
     ),
     skipSchemas = List.empty,
     telemetry = Telemetry.Config(
@@ -179,8 +180,9 @@ object PubsubConfigSpec {
     ),
     cpuParallelismFactor = BigDecimal(0.75),
     retries = Config.Retries(
-      setupErrors     = Retrying.Config.ForSetup(delay = 30.seconds),
-      transientErrors = Retrying.Config.ForTransient(delay = 1.second, attempts = 5)
+      setupErrors          = Retrying.Config.ForSetup(delay = 30.seconds),
+      transientErrors      = Retrying.Config.ForTransient(delay = 1.second, attempts = 5),
+      checkCommittedOffset = Config.CheckCommittedOffsetRetries(delay = 100.millis)
     ),
     skipSchemas = List(
       SchemaCriterion.parse("iglu:com.acme/skipped1/jsonschema/1-0-0").get,


### PR DESCRIPTION
Jira ref: [PDP-1975](https://snplow.atlassian.net/browse/PDP-1975)

Until now, we have (effectively) used response codes from Snowflake to tell us that the events are safely in Snowflake. This was done via the snowflake java sdk; specifically, if `.flush()` returns with no error then we assumed the events are in snowflake.

But we hit edge cases where snowflake would response with a successful response code, but the events were not fully ingested into the table. This edge case can happen around the time of schema evolution.

After this PR, we use offset tokens to check the ingestion of a batch of events. We do not assume the batch is ingested to the table until `channel.getLatestCommittedOffsetToken()` returns the expected offset.

[PDP-1975]: https://snplow.atlassian.net/browse/PDP-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ